### PR TITLE
git tag checkout syntax (most proper)

### DIFF
--- a/site/src/partials/get-code.html.eco
+++ b/site/src/partials/get-code.html.eco
@@ -21,9 +21,9 @@
       <pre class="console">git clone https://github.com/camunda/<%= @repo %>.git</pre>
       To follow this guide, <a href="https://github.com/camunda/<%= @repo %>/archive/Start.zip">download</a>
       the initial state or checkout the tag in the git repositiory:
-      <pre class="console">git checkout -f Start</pre>
+      <pre class="console">git checkout -f tags/Start</pre>
       or every step in between:
-      <pre class="console">git checkout -f Step-X</pre>
+      <pre class="console">git checkout -f tags/Step-X</pre>
 
       After every section in this guide you will find a box which contains a download link to the current
       state of the project and git instructions to checkout the current version of the repository.

--- a/site/src/partials/get-tag.html.eco
+++ b/site/src/partials/get-tag.html.eco
@@ -24,7 +24,7 @@
         </p>
         <p>
         To checkout the current state of the process application please execute the following command:
-        <pre class="console">git checkout -f <%= @tag %></pre>
+        <pre class="console">git checkout -f tags/<%= @tag %></pre>
         Or download as archive from <a href="https://github.com/camunda/<%= @repo %>/releases/tag/<%= @tag %>">here</a>.
         </p>
       </div>


### PR DESCRIPTION
the proper way to reference a tag is with the `tags/` prefix