### PR TITLE
fix(rest-api): The names of query parameters are fixed.

### DIFF
--- a/site/src/documents/api-references/rest/process-definition/get-query-count.html.md
+++ b/site/src/documents/api-references/rest/process-definition/get-query-count.html.md
@@ -58,11 +58,11 @@ Parameters
     <td>Filter by process definition categories that the parameter is a substring of.</td>
   </tr>
   <tr>
-    <td>version</td>
+    <td>ver</td>
     <td>Filter by process definition version.</td>
   </tr>
   <tr>
-    <td>latestVersion</td>
+    <td>latest</td>
     <td>Only include those process definitions that are latest versions. Values may be <code>true</code> or <code>false</code>.</td>
   </tr>
   <tr>


### PR DESCRIPTION
In REST API: Get Definition count
The query parameters version and latestVersion are invalid. The valid parameters are ver and latest respectively.